### PR TITLE
Fix debugger not found message

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 ## Troubleshooting
 
-- Error:** `Debugger not found`
-  - **Solution:** Make sure that `cdb.exe` is installed in the expected location.
+ - Error:** `Debugger not found`
+   - **Solution:** `cdb.exe` could not be found. Please install the Windows debugging tools.
 
 
 ## German:

--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ def analyze_dump(dump_file_path, ticket_number):
     debugger_path = find_cdb_executable()
     if debugger_path is None:
         flash(_('cdb.exe could not be found. Please install the Windows debugging tools.'))
-        return _("Debugger not found", "Please install the Windows Debugging Tools.")
+        return _("Debugger not found"), _("cdb.exe could not be found. Please install the Windows debugging tools.")
 
     command = f'"{debugger_path}" -z "{dump_file_path}" -c "!analyze -v; q"'
 


### PR DESCRIPTION
## Summary
- fix analyze_dump return message for missing debugger
- update troubleshooting docs for missing debugger

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6842d2ca273c832fa7e7ac852ddd0f86