### PR TITLE
Expand pytest coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def app_module(monkeypatch):
+    """Import ``app`` with minimal stubs so tests run without Flask."""
+
+    # Create minimal flask stub
+    flask_stub = types.ModuleType("flask")
+
+    class Flask:
+        def __init__(self, name):
+            self.jinja_env = types.SimpleNamespace(add_extension=lambda ext: None)
+            self.config = {}
+
+        def route(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def context_processor(self, func):
+            return func
+
+    flask_stub.Flask = Flask
+    flask_stub.request = None
+    flask_stub.redirect = lambda *a, **k: None
+    flask_stub.url_for = lambda *a, **k: ""
+    flask_stub.render_template = lambda *a, **k: ""
+    flask_stub.flash = lambda *a, **k: None
+    flask_stub.send_from_directory = lambda *a, **k: None
+    flask_stub.session = {}
+    monkeypatch.setitem(sys.modules, "flask", flask_stub)
+
+    # flask_babel stub
+    babel_stub = types.ModuleType("flask_babel")
+
+    class Babel:
+        def __init__(self, app, locale_selector=None):
+            self.app = app
+            self.locale_selector = locale_selector
+
+    babel_stub.Babel = Babel
+    babel_stub.gettext = lambda s, *a, **k: s
+    monkeypatch.setitem(sys.modules, "flask_babel", babel_stub)
+
+    # markdown stub
+    monkeypatch.setitem(sys.modules, "markdown", types.ModuleType("markdown"))
+
+    module = importlib.import_module("app")
+    try:
+        yield module
+    finally:
+        importlib.reload(module)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,77 @@
+import types
+
+import pytest
+
+
+def test_validate_url_valid(app_module):
+    assert app_module.validate_url('/changelog') == '/changelog'
+
+
+def test_validate_url_invalid(app_module):
+    # invalid because of query string
+    assert app_module.validate_url('/changelog?bad=1') == '/'
+
+
+def test_validate_url_fragment(app_module):
+    assert app_module.validate_url('/changelog#frag') == '/'
+
+
+def test_validate_url_unknown_path(app_module):
+    assert app_module.validate_url('/evil') == '/'
+
+
+def test_is_safe_url(app_module, monkeypatch):
+    app_module.request = types.SimpleNamespace(host_url='http://localhost:5000/')
+    assert app_module.is_safe_url('http://localhost:5000/changelog') is True
+    assert app_module.is_safe_url('https://evil.com/') is False
+
+
+def test_get_locale(app_module):
+    app_module.session['lang'] = 'de'
+    assert app_module.get_locale() == 'de'
+    app_module.session.clear()
+    assert app_module.get_locale() == 'en'
+
+
+def test_find_cdb_executable(app_module, monkeypatch):
+    called = []
+
+    def fake_exists(path):
+        called.append(path)
+        expected = r'C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe'
+        return path == expected
+
+    monkeypatch.setattr(app_module.os.path, 'exists', fake_exists)
+    result = app_module.find_cdb_executable()
+    assert result in called
+
+
+def test_find_cdb_executable_none(app_module, monkeypatch):
+    monkeypatch.setattr(app_module.os.path, 'exists', lambda p: False)
+    assert app_module.find_cdb_executable() is None
+
+
+def test_analyze_dump_no_debugger(app_module, monkeypatch):
+    monkeypatch.setattr(app_module, 'find_cdb_executable', lambda: None)
+    result = app_module.analyze_dump('dummy', 1)
+    assert result == 'Debugger not found'
+
+
+def test_analyze_dump_success(app_module, monkeypatch, tmp_path):
+    # fake debugger path
+    monkeypatch.setattr(app_module, 'find_cdb_executable', lambda: '/path/cdb.exe')
+
+    class DummyProcess:
+        def communicate(self, timeout=None):
+            out = 'PROCESS_NAME: myapp.exe\nExceptionCode: 0xC0000005\n'
+            return out.encode(), b''
+
+    monkeypatch.setattr(app_module.subprocess, 'Popen', lambda *a, **k: DummyProcess())
+
+    app_module.app.config['ANALYSIS_FOLDER'] = str(tmp_path)
+    exe, reason = app_module.analyze_dump('dump.dmp', 42)
+    assert exe == 'myapp.exe'
+    assert reason == '0xC0000005 - Access Violation'
+    analysis_file = tmp_path / 'analysis_42.txt'
+    assert analysis_file.exists()
+    assert 'PROCESS_NAME: myapp.exe' in analysis_file.read_text()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,62 +1,3 @@
-import importlib
-import sys
-import types
-
-import pytest
-
-
-@pytest.fixture
-def app_module(monkeypatch):
-    """Import ``app`` with minimal stubs so tests run without Flask."""
-
-    # Create minimal flask stub
-    flask_stub = types.ModuleType("flask")
-
-    class Flask:
-        def __init__(self, name):
-            self.jinja_env = types.SimpleNamespace(add_extension=lambda ext: None)
-            self.config = {}
-
-        def route(self, *args, **kwargs):
-            def decorator(func):
-                return func
-
-            return decorator
-
-        def context_processor(self, func):
-            return func
-
-    flask_stub.Flask = Flask
-    flask_stub.request = None
-    flask_stub.redirect = lambda *a, **k: None
-    flask_stub.url_for = lambda *a, **k: ""
-    flask_stub.render_template = lambda *a, **k: ""
-    flask_stub.flash = lambda *a, **k: None
-    flask_stub.send_from_directory = lambda *a, **k: None
-    flask_stub.session = {}
-    monkeypatch.setitem(sys.modules, "flask", flask_stub)
-
-    # flask_babel stub
-    babel_stub = types.ModuleType("flask_babel")
-
-    class Babel:
-        def __init__(self, app, locale_selector=None):
-            self.app = app
-            self.locale_selector = locale_selector
-
-    babel_stub.Babel = Babel
-    babel_stub.gettext = lambda s, *a, **k: s
-    monkeypatch.setitem(sys.modules, "flask_babel", babel_stub)
-
-    # markdown stub
-    monkeypatch.setitem(sys.modules, "markdown", types.ModuleType("markdown"))
-
-    module = importlib.import_module("app")
-    try:
-        yield module
-    finally:
-        importlib.reload(module)
-
 
 def test_known_exception_code(app_module):
     assert app_module.get_exception_description('0xC0000005') == 'Access Violation'
@@ -69,4 +10,8 @@ def test_known_code_case_insensitive(app_module):
 
 def test_unknown_exception_code(app_module):
     assert app_module.get_exception_description('0xDEADBEEF') == 'Unknown error'
+
+
+def test_exception_description_strip_prefix(app_module):
+    assert app_module.get_exception_description(' C00000FD ') == 'Stack Overflow'
 


### PR DESCRIPTION
## Summary
- add fixture `app_module` in test configuration
- test URL validation, debugger discovery, locale detection
- test exception description parsing and dump analysis logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842daada884832fbe4cd57ff7f1a9de