### PR TITLE
Add accessibility attributes and CSRF token

### DIFF
--- a/templates/analysis.html
+++ b/templates/analysis.html
@@ -8,7 +8,7 @@
 <body>
         <div id="overlay" class="overlay" onclick="toggleSettingsMenu()"></div>
         <!-- Einstellungen-Icon -->
-        <div class="settings-icon" onclick="toggleSettingsMenu()">
+        <div class="settings-icon" onclick="toggleSettingsMenu()" role="button" tabindex="0" aria-label="Settings">
             &#9881;
         </div>
     

--- a/templates/changelog.html
+++ b/templates/changelog.html
@@ -9,7 +9,7 @@
 <body>
     <div id="overlay" class="overlay" onclick="toggleSettingsMenu()"></div>
     <!-- Einstellungen-Icon -->
-    <div class="settings-icon" onclick="toggleSettingsMenu()">
+    <div class="settings-icon" onclick="toggleSettingsMenu()" role="button" tabindex="0" aria-label="Settings">
         &#9881;
     </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <body>
     <div id="overlay" class="overlay" onclick="toggleSettingsMenu()"></div>
     <!-- Einstellungen-Icon -->
-    <div class="settings-icon" onclick="toggleSettingsMenu()">
+    <div class="settings-icon" onclick="toggleSettingsMenu()" role="button" tabindex="0" aria-label="Settings">
         &#9881;
     </div>
 
@@ -94,6 +94,7 @@
 
     <h2>{{ _('Administrator actions') }}</h2>
     <form method="post" action="{{ url_for('clear_dumps') }}" class="admin-form upload-form">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
         <button type="submit" class="btn-clear">{{ _('Clear dump files') }}</button>
     </form>
 


### PR DESCRIPTION
## Summary
- improve accessibility for settings icon in all templates
- add CSRF token generation and verification
- include CSRF token in the clear dumps form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b9bc6f644832fbcaac1696c21b09d